### PR TITLE
Tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,14 @@ ENV LIBGUESTFS_BACKEND direct
 
 RUN dnf update -y && \
     dnf install -y --setopt=install_weak_deps=False \
-        libguestfs-devel \
-        qemu-img
+        libguestfs-devel
 
 # Create tarball for the appliance. This fixed libguestfs appliance uses the root in qcow2 format as container runtime not always handle correctly sparse files.
 RUN mkdir -p /usr/local/lib/guestfs/appliance && \
-    libguestfs-make-fixed-appliance /usr/local/lib/guestfs/appliance && \
     cd /usr/local/lib/guestfs/appliance && \
-    qemu-img convert -c -O qcow2 root root.qcow2 && \
-    mv root.qcow2 root
+    libguestfs-make-fixed-appliance --xz
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 RUN mkdir -p /usr/lib64/guestfs
-COPY --from=centos /usr/local/lib/guestfs/appliance /usr/lib64/guestfs
+COPY --from=centos /usr/local/lib/guestfs/appliance/appliance-*.tar.xz /usr/lib64/guestfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream8 as centos
 
 ENV LIBGUESTFS_BACKEND direct
 
@@ -8,9 +8,13 @@ RUN dnf update -y && \
         qemu-img
 
 # Create tarball for the appliance. This fixed libguestfs appliance uses the root in qcow2 format as container runtime not always handle correctly sparse files.
-RUN mkdir -p /usr/lib64/guestfs/appliance && \
-    libguestfs-make-fixed-appliance /usr/lib64/guestfs/appliance && \
-    cd /usr/lib64/guestfs/appliance && \
+RUN mkdir -p /usr/local/lib/guestfs/appliance && \
+    libguestfs-make-fixed-appliance /usr/local/lib/guestfs/appliance && \
+    cd /usr/local/lib/guestfs/appliance && \
     qemu-img convert -c -O qcow2 root root.qcow2 && \
     mv root.qcow2 root
 
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+RUN mkdir -p /usr/lib64/guestfs
+COPY --from=centos /usr/local/lib/guestfs/appliance /usr/lib64/guestfs


### PR DESCRIPTION
libguestfs in EL8 cannot use appliance in QCOW2. Use compressed tar archive for transport.